### PR TITLE
Fix panel chevron toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -760,15 +760,24 @@ body.dragging-bottom #chevBottomEdge { opacity:0; pointer-events:none; }
       splitL?.addEventListener('mousedown', e=>startDrag(e,'L'));
       splitR?.addEventListener('mousedown', e=>startDrag(e,'R'));
       splitB?.addEventListener('mousedown', e=>startDrag(e,'B'));
+    })();
 
-      // Chevron toggles in panel headers
-      document.getElementById('chevLeft')?.addEventListener('click', ()=>{ document.body.classList.toggle('left-collapsed'); setCanvasSizeToContainer?.(); });
-      document.getElementById('chevRight')?.addEventListener('click', ()=>{ document.body.classList.toggle('right-collapsed'); setCanvasSizeToContainer?.(); });
-      document.getElementById('chevBottom')?.addEventListener('click', ()=>{ document.body.classList.toggle('bottom-collapsed'); setCanvasSizeToContainer?.(); });
+    // ---- Panel chevron toggles ----
+    (function(){
+      ['Left','Right','Bottom'].forEach(pos => {
+        const cls = `${pos.toLowerCase()}-collapsed`;
+        document.getElementById(`chev${pos}`)?.addEventListener('click', () => {
+          document.body.classList.toggle(cls);
+          setCanvasSizeToContainer?.();
+        });
+        document.getElementById(`chev${pos}Edge`)?.addEventListener('click', () => {
+          document.body.classList.remove(cls);
+          setCanvasSizeToContainer?.();
+        });
+      });
     })();
 
 
-    
     // ---- Background normalization (paper whitening) ----
     
     async function normalizePaperIfEnabled(){
@@ -812,27 +821,9 @@ body.dragging-bottom #chevBottomEdge { opacity:0; pointer-events:none; }
         drawBase(); redrawOverlay();
       }catch(e){ console.warn('normalizePaperIfEnabled failed', e); }
     }
-        window.rawImageData = new ImageData(out, imgW, imgH);
-        // Update displayed bitmap
-        let disp = document.createElement('canvas'); disp.width = imgW; disp.height = imgH;
-        disp.getContext('2d').putImageData(rawImageData, 0, 0);
-        window.imgBitmap = disp;
-        drawBase(); redrawOverlay();
-      }catch(e){ console.warn('normalizePaperIfEnabled failed', e); }
-    }
 
 
     
-    // Edge chevrons to reopen collapsed panels
-    (function(){
-      document.getElementById('chevLeftEdge')?.addEventListener('click', ()=>{ document.body.classList.remove('left-collapsed'); setCanvasSizeToContainer?.(); });
-      document.getElementById('chevRightEdge')?.addEventListener('click', ()=>{ document.body.classList.remove('right-collapsed'); setCanvasSizeToContainer?.(); });
-      document.getElementById('chevBottomEdge')?.addEventListener('click', ()=>{ document.body.classList.remove('bottom-collapsed'); setCanvasSizeToContainer?.(); });
-    })();
-
-
-    
-    (function(){ const btn = document.getElementById('chevLeft'); if (btn) btn.addEventListener('click', ()=>{ document.body.classList.toggle('left-collapsed'); setCanvasSizeToContainer?.(); }); })();
     // ---- Tracing core ----
     function getHighlightR(){ return Math.max(1, Math.round(+thickness.value / 2)); }
 


### PR DESCRIPTION
## Summary
- Ensure left, right, and bottom panels can be hidden or reopened using their chevron buttons by wiring generic toggle logic
- Clean stray duplicate code from the paper normalization helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5bc16e48325bdda2e376f63830d